### PR TITLE
fix a translation mistake for zh_CN

### DIFF
--- a/config/translations/lxqt-config-notificationd_zh_CN.desktop
+++ b/config/translations/lxqt-config-notificationd_zh_CN.desktop
@@ -1,4 +1,4 @@
 # Translations
 GenericName[zh_CN]=qxkb
-Name[zh_CN]=LxQt 鼠标配置
+Name[zh_CN]=LxQt 通知配置
 Comment[zh_CN]=配置 LxQt 桌面的通知


### PR DESCRIPTION
The origin translation means mouse settings.
