### PR TITLE
- Unify naming for a unique lxqt. No more suffixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(Qt5DBus REQUIRED QUIET)
 find_package(Qt5LinguistTools REQUIRED QUIET)
 find_package(KF5WindowSystem REQUIRED QUIET)
 
-find_package(lxqt-qt5 REQUIRED QUIET)
+find_package(lxqt REQUIRED QUIET)
 find_package(qt5xdg REQUIRED)
 
 include(${LXQT_USE_FILE})


### PR DESCRIPTION
Signed-off-by: Helio Chissini de Castro helio@kde.org
