### PR TITLE
notificationlayout: Remove the "on top" hint

### DIFF
--- a/src/notificationlayout.cpp
+++ b/src/notificationlayout.cpp
@@ -42,9 +42,6 @@ NotificationLayout::NotificationLayout(QWidget *parent)
     // Required to display wallpaper
     setAttribute(Qt::WA_TranslucentBackground);
 
-    // Make the window stay on top
-    setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
-
     m_layout = new QVBoxLayout(this);
     m_layout->setMargin(0);
     setLayout(m_layout);


### PR DESCRIPTION
Remove Qt::WindowStaysOnTopHint from window flags as this is not the
top level window.

May this be the reason for problems with the tilling managers (ref. lxde/lxqt#1345)?