### PR TITLE
Qt 5.11 beta: notification.cpp: include QStyleOption explicitely

### DIFF
--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -35,6 +35,7 @@
 #include <KWindowSystem/KWindowSystem>
 #include <QMouseEvent>
 #include <QPushButton>
+#include <QStyleOption>
 
 #include "notification.h"
 #include "notificationwidgets.h"


### PR DESCRIPTION
5.11 Qt headers do not indirectly include QStyleOption resulting in compile
time errors like:
| notification.cpp:219:5: error: 'QStyleOption' was not declared in this scope

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>