### PR TITLE
Keep notification height when other are added and removed

### DIFF
--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -60,6 +60,7 @@ Notification::Notification(const QString &application,
 
     setMaximumWidth(parent->width());
     setMinimumWidth(parent->width());
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
     setValues(application, summary, body, icon, timeout, actions, hints);
 

--- a/test/lxqt-notification-test-overflow.sh
+++ b/test/lxqt-notification-test-overflow.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# required: notify-send app installed (part of libnotify, or libnotify-tools)
+#
+
+notify-send -t 8000 "tested notification" "Is it still the same size?" &
+
+sleep 2
+
+for i in $(seq 10)
+do
+    notify-send -t 4000 "a notification" "4 seconds notification #${i}" &
+done
+
+for i in $(seq 40)
+do
+    notify-send -t 2000 "a notification" "2 seconds notification #${i}" &
+done
+


### PR DESCRIPTION
When you open many notifications, they become higher and higher when closing them. This is a fix for the issue.