### PR TITLE
Never miss a notification

### DIFF
--- a/config/advancedsettings.cpp
+++ b/config/advancedsettings.cpp
@@ -38,9 +38,11 @@ AdvancedSettings::AdvancedSettings(LXQt::Settings* settings, QWidget *parent):
     setupUi(this);
     restoreSettings();
 
-    connect(serverDecidesBox, SIGNAL(valueChanged(int)), this, SLOT(save()));
-    connect(spacingBox, SIGNAL(valueChanged(int)), this, SLOT(save()));
-    connect(widthBox, SIGNAL(valueChanged(int)), this, SLOT(save()));
+    connect(serverDecidesBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &AdvancedSettings::save);
+    connect(spacingBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &AdvancedSettings::save);
+    connect(widthBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &AdvancedSettings::save);
+    connect(unattendedBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &AdvancedSettings::save);
+    connect(blackListEdit, &QLineEdit::editingFinished, this, &AdvancedSettings::save);
 }
 
 AdvancedSettings::~AdvancedSettings()
@@ -56,6 +58,8 @@ void AdvancedSettings::restoreSettings()
 
     spacingBox->setValue(mSettings->value(QL1S("spacing"), 6).toInt());
     widthBox->setValue(mSettings->value(QL1S("width"), 300).toInt());
+    unattendedBox->setValue(mSettings->value(QL1S("unattendedMaxNum"), 0).toInt());
+    blackListEdit->setText(mSettings->value(QL1S("blackList")).toStringList().join (QL1S(",")));
 }
 
 void AdvancedSettings::save()
@@ -63,4 +67,14 @@ void AdvancedSettings::save()
     mSettings->setValue(QL1S("server_decides"), serverDecidesBox->value());
     mSettings->setValue(QL1S("spacing"), spacingBox->value());
     mSettings->setValue(QL1S("width"), widthBox->value());
+    mSettings->setValue(QL1S("unattendedMaxNum"), unattendedBox->value());
+    QString blackList = blackListEdit->text();
+    if (!blackList.isEmpty())
+    {
+        QStringList l = blackList.split(QL1S(","), QString::SkipEmptyParts);
+        l.removeDuplicates();
+        mSettings->setValue(QL1S("blackList"), l);
+    }
+    else
+        mSettings->remove(QL1S("blackList"));
 }

--- a/config/advancedsettings.ui
+++ b/config/advancedsettings.ui
@@ -108,7 +108,7 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -120,6 +120,50 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Unattended Notifications</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QLabel" name="unattendedLabel">
+          <property name="text">
+           <string>How many to save:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="unattendedBox"/>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <item>
+         <widget class="QLabel" name="blackListLabel">
+          <property name="text">
+           <string>Ignore these applications:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="blackListEdit">
+          <property name="placeholderText">
+           <string>app1,app2,app3</string>
+          </property>
+          <property name="clearButtonEnabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -52,7 +52,11 @@ Notification::Notification(const QString &application,
     : QWidget(parent),
       m_timer(0),
       m_linkHovered(false),
-      m_actionWidget(0)
+      m_actionWidget(0),
+      m_icon(icon),
+      m_timeout(timeout),
+      m_actions(actions),
+      m_hints(hints)
 {
     setupUi(this);
     setObjectName(QSL("Notification"));

--- a/src/notification.h
+++ b/src/notification.h
@@ -68,6 +68,19 @@ public:
     QString summary() const;
     QString body() const;
 
+    QString icon() const {
+        return m_icon;
+    }
+    int timeOut() const {
+        return m_timeout;
+    }
+    QStringList actions() const {
+        return m_actions;
+    }
+    QVariantMap hints() const {
+        return m_hints;
+    }
+
 signals:
     //! the server set timeout passed. Notification should close itself.
     void timeout();
@@ -102,6 +115,11 @@ private:
     bool m_linkHovered;
 
     NotificationActionsWidget *m_actionWidget;
+
+    QString m_icon;
+    int m_timeout;
+    QStringList m_actions;
+    QVariantMap m_hints;
 
     // mandatory for stylesheets
     void paintEvent(QPaintEvent *);

--- a/src/notificationarea.cpp
+++ b/src/notificationarea.cpp
@@ -121,7 +121,7 @@ void NotificationArea::setHeight(int contentHeight)
     ensureVisible(0, contentHeight, 0, 0);
 }
 
-void NotificationArea::setSettings(const QString &placement, int width, int spacing)
+void NotificationArea::setSettings(const QString &placement, int width, int spacing, int unattendedMaxNum, const QStringList &blackList)
 {
     m_placement = placement;
 
@@ -132,4 +132,7 @@ void NotificationArea::setSettings(const QString &placement, int width, int spac
     m_layout->setSizes(m_spacing, width);
 
     this->setHeight(widget()->height());
+
+    m_layout->setUnattendedMaxNum(unattendedMaxNum);
+    m_layout->setBlackList(blackList);
 }

--- a/src/notificationarea.h
+++ b/src/notificationarea.h
@@ -51,8 +51,10 @@ public:
      * \param placement a string name for notification location "top-level" etc.
      * \param width set with of notifications
      * \param spacing a spacing in the \NotificationLayout
+     * \param unattendedMaxNum the max. number of unattended notifications to be saved
+     * \param blackList the list of apps whose unattended notifications aren't saved
      */
-    void setSettings(const QString &placement, int width, int spacing);
+    void setSettings(const QString &placement, int width, int spacing, int unattendedMaxNum, const QStringList &blackList);
 
 private:
     NotificationLayout *m_layout;

--- a/src/notificationlayout.h
+++ b/src/notificationlayout.h
@@ -43,6 +43,24 @@ public:
      */
     void setSizes(int space, int width);
 
+    int getUnattendedMaxNum() const {
+        return m_unattendedMaxNum;
+    }
+    void setUnattendedMaxNum(int num) {
+        m_unattendedMaxNum = num;
+    }
+
+    void setBlackList(const QStringList &l) {
+        m_blackList = l;
+    }
+
+    QString cacheFile() const {
+        return m_cacheFile;
+    }
+    QString cacheDateFormat() const {
+        return m_cacheDateFormat;
+    }
+
 signals:
     //! All \c Notification instances are closed
     void allNotificationsClosed();
@@ -54,8 +72,9 @@ signals:
     /*! Promote the internal change of notification closing into the \c Notifyd
      * \param id an notification ID (obtained from \c Notify)
      * \param reason a reason for closing code. See specification for more info.
+     * \param date the exact moment of closing.
      */
-    void notificationClosed(uint id, uint reason);
+    void notificationClosed(uint id, uint reason, const QString &date);
 
     /*! Inform the external application that user chose one of provided action via the \c Notifyd
      * \param in0 a notification ID (obtained from \c Notify)
@@ -70,7 +89,8 @@ public slots:
     void addNotification(uint id, const QString &application,
                          const QString &summary, const QString &body,
                          const QString &icon, int timeout,
-                         const QStringList& actions, const QVariantMap& hints);
+                         const QStringList& actions, const QVariantMap& hints,
+                         bool noSave = false);
 
     /*! Notification id should be removed because of reason
      */
@@ -79,6 +99,10 @@ public slots:
 private:
     QHash<uint, Notification*> m_notifications;
     QVBoxLayout *m_layout;
+    int m_unattendedMaxNum;
+    QStringList m_blackList;
+    QString m_cacheFile;
+    QString m_cacheDateFormat;
 
     /*! Calculate required height based on height of each \c Notification
      * in the m_notifications map.

--- a/src/notifyd.cpp
+++ b/src/notifyd.cpp
@@ -28,6 +28,7 @@
 
 #include "notifyd.h"
 
+#include <QProcess>
 #include <QDebug>
 
 
@@ -37,7 +38,8 @@
 
 Notifyd::Notifyd(QObject* parent)
     : QObject(parent),
-      mId(0)
+      mId(0),
+      m_trayChecker(0)
 {
     m_area = new NotificationArea();
     m_settings = new LXQt::Settings(QSL("notifications"));
@@ -49,7 +51,11 @@ Notifyd::Notifyd(QObject* parent)
             m_area->layout(), &NotificationLayout::removeNotification);
     // feedback for original caller
     connect(m_area->layout(), &NotificationLayout::notificationClosed,
-            this, &Notifyd::NotificationClosed);
+            [this] (uint id, uint reason, const QString& /*date*/) {
+                emit NotificationClosed(id, reason);
+            });
+    connect(m_area->layout(), &NotificationLayout::notificationClosed,
+            this, &Notifyd::addToUnattendedList);
     connect(m_area->layout(), &NotificationLayout::actionInvoked,
             this, &Notifyd::ActionInvoked);
 
@@ -60,6 +66,8 @@ Notifyd::Notifyd(QObject* parent)
 
 Notifyd::~Notifyd()
 {
+    m_trayMenu->deleteLater();
+    m_trayIcon->deleteLater();
     m_area->deleteLater();
 }
 
@@ -103,8 +111,8 @@ uint Notifyd::Notify(const QString& app_name,
                      const QString& body,
                      const QStringList& actions,
                      const QVariantMap& hints,
-                     int expire_timeout
-                     )
+                     int expire_timeout,
+                     bool noSave)
 {
     uint ret;
     if (replaces_id == 0)
@@ -133,7 +141,7 @@ uint Notifyd::Notify(const QString& app_name,
         expire_timeout *= 1000;
     }
 
-    emit notificationAdded(ret, app_name, summary, body, app_icon, expire_timeout, actions, hints);
+    emit notificationAdded(ret, app_name, summary, body, app_icon, expire_timeout, actions, hints, noSave);
 
     return ret;
 }
@@ -141,8 +149,189 @@ uint Notifyd::Notify(const QString& app_name,
 void Notifyd::reloadSettings()
 {
     m_serverTimeout = m_settings->value(QSL("server_decides"), 10).toInt();
+    int maxNum = m_settings->value(QSL("unattendedMaxNum"), 0).toInt();
     m_area->setSettings(
             m_settings->value(QSL("placement"), QSL("bottom-right")).toString().toLower(),
             m_settings->value(QSL("width"), 300).toInt(),
-            m_settings->value(QSL("spacing"), 6).toInt());
+            m_settings->value(QSL("spacing"), 6).toInt(),
+            maxNum,
+            m_settings->value(QSL("blackList")).toStringList());
+
+    if (maxNum > 0 && m_trayIcon.isNull())
+    { // create the tray icon
+        if (QSystemTrayIcon::isSystemTrayAvailable())
+            createTrayIcon();
+        else // check the tray's presence every 5 seconds (see checkTray)
+        {
+            QTimer *trayTimer = new QTimer(this);
+            trayTimer->setSingleShot(true);
+            trayTimer->setInterval(5000);
+            connect(trayTimer, &QTimer::timeout, this, &Notifyd::checkTray);
+            trayTimer->start();
+            ++ m_trayChecker;
+        }
+    }
+    else if (maxNum == 0 && !m_trayIcon.isNull())
+    { // remove the tray icon
+        m_trayMenu->deleteLater();
+        m_trayIcon->deleteLater();
+    }
+}
+
+// Creates the tray icon and populates its context menu.
+void Notifyd::createTrayIcon()
+{
+    if (m_trayMenu.isNull())
+        m_trayMenu = new QMenu();
+    else
+        m_trayMenu->clear();
+
+    if (m_trayIcon.isNull())
+    {
+        m_trayIcon = new QSystemTrayIcon(QIcon::fromTheme(QSL("preferences-desktop-notification")), this);
+        /* show the menu also on left clicking */
+        connect(m_trayIcon, &QSystemTrayIcon::activated, [this] (QSystemTrayIcon::ActivationReason r) {
+            if (r == QSystemTrayIcon::Trigger && !m_trayMenu.isNull())
+                m_trayMenu->exec(QCursor::pos());
+        });
+    }
+
+    QSettings list(m_area->layout()->cacheFile(), QSettings::IniFormat);
+    QStringList dates = list.childGroups();
+    if (!dates.isEmpty())
+        dates.sort();
+
+    QAction *action = nullptr;
+    // add items for notification, starting from the oldest one and from bottom to top
+    for (const QString date : qAsConst(dates))
+    {
+        list.beginGroup(date);
+        // "DATE_AND_TIME - APP: SUMMARY"
+        QString txt = QDateTime::fromString(date, m_area->layout()->cacheDateFormat())
+                        .toString(Qt::SystemLocaleShortDate) // for human readability
+                        + QL1S(" - ") + list.value(QL1S("Application")).toString() + QL1S(": ")
+                        + list.value(QL1S("Summary")).toString();
+        list.endGroup();
+        QAction *thisAction = new QAction(txt, m_trayMenu);
+        thisAction->setData(date);
+        m_trayMenu->insertAction(action, thisAction);
+        action = thisAction;
+        connect(thisAction, &QAction::triggered, this, &Notifyd::restoreUnattended);
+    }
+
+    // add a separator
+    m_trayMenu->addSeparator();
+
+    // "Clear All"
+    action = m_trayMenu->addAction(QIcon::fromTheme(QSL("edit-clear")), tr("Clear All"));
+    connect(action, &QAction::triggered, m_trayMenu, [this] {
+        m_trayIcon->setVisible(false);
+        m_trayMenu->deleteLater();
+        QSettings(m_area->layout()->cacheFile(), QSettings::IniFormat).clear();
+    });
+
+    // "Options"
+    action = m_trayMenu->addAction(QIcon::fromTheme(QSL("preferences-system")), tr("Options"));
+    connect(action, &QAction::triggered, m_trayMenu, [] {
+        QProcess::startDetached(QSL("lxqt-config-notificationd"));
+    });
+
+    m_trayIcon->setContextMenu(m_trayMenu);
+    m_trayIcon->setVisible(!dates.isEmpty());
+    m_trayIcon->setToolTip(tr("%1 Unattended Notification(s)")
+                            .arg(m_trayMenu->actions().size() - 3));
+}
+
+// NOTE: Contrary to what Qt doc implies, if the tray icon is created before the tray area is available,
+// it will never be shown. This function checks the tray's presence every 5 seconds for one minute.
+void Notifyd::checkTray()
+{
+    if (QTimer *trayTimer = qobject_cast<QTimer*>(sender()))
+    {
+        if (QSystemTrayIcon::isSystemTrayAvailable())
+        {
+            trayTimer->deleteLater();
+            createTrayIcon();
+        }
+        else if (m_trayChecker < 12)
+        {
+            trayTimer->start();
+            ++ m_trayChecker;
+        }
+        else
+            trayTimer->deleteLater();
+    }
+}
+
+void Notifyd::addToUnattendedList(uint /*id*/, uint reason, const QString &date)
+{
+    // process the notifications if it's unattended and not blacklisted
+    if (reason == 1 && !date.isEmpty() && m_area->layout()->getUnattendedMaxNum() > 0)
+    {
+        if (m_trayIcon.isNull() || m_trayMenu.isNull())
+        {
+            if (QSystemTrayIcon::isSystemTrayAvailable())
+                createTrayIcon();
+        }
+        else
+        {
+            // Add it to the top of the current tray menu, removing the oldest items if the list is full.
+            // A separator, "Clear All" and "Options" exist after all items.
+            QList<QAction*> actions = m_trayMenu->actions();
+            while (actions.size() >= m_area->layout()->getUnattendedMaxNum() + 3)
+            {
+                m_trayMenu->removeAction(actions.at(actions.size() - 4));
+                delete actions.takeAt(actions.size() - 4);
+            }
+            QSettings list(m_area->layout()->cacheFile(), QSettings::IniFormat);
+            list.beginGroup(date);
+            QString txt = QDateTime::fromString(date, m_area->layout()->cacheDateFormat())
+                            .toString(Qt::SystemLocaleShortDate) // for human readability
+                            + QL1S(" - ") + list.value(QL1S("Application")).toString() + QL1S(": ")
+                            + list.value(QL1S("Summary")).toString();
+            list.endGroup();
+            QAction *action = new QAction(txt, m_trayMenu);
+            action->setData(date);
+            m_trayMenu->insertAction(actions.isEmpty() ? nullptr : actions.first(), action);
+            connect(action, &QAction::triggered, this, &Notifyd::restoreUnattended);
+            m_trayIcon->setVisible(true);
+            m_trayIcon->setToolTip(tr("%1 Unattended Notification(s)")
+                                    .arg(m_trayMenu->actions().size() - 3));
+        }
+    }
+}
+
+void Notifyd::restoreUnattended()
+{
+    if (QAction *action = qobject_cast<QAction*>(sender()))
+    {
+        const QString date = action->data().toString();
+        m_trayMenu->removeAction(action);
+        delete action;
+        if (m_trayMenu->actions().size() == 3) // separator, "Clear All" and "Options" exist
+        {
+            m_trayIcon->setVisible(false);
+            // NOTE: If the menu isn't deleted here, it won't be shown later (a Qt bug?).
+            m_trayMenu->deleteLater();
+        }
+        else
+            m_trayIcon->setToolTip(tr("%1 Unattended Notification(s)")
+                                    .arg(m_trayMenu->actions().size() - 3));
+        QSettings list(m_area->layout()->cacheFile(), QSettings::IniFormat);
+        if (list.childGroups().contains(date))
+        {
+            list.beginGroup(date);
+            Notify(list.value(QL1S("Application")).toString(),
+                0,
+                list.value(QL1S("Icon")).toString(),
+                list.value(QL1S("Summary")).toString(),
+                list.value(QL1S("Body")).toString(),
+                list.value(QL1S("Actions")).toStringList(),
+                list.value(QL1S("Hints")).toMap(),
+                list.value(QL1S("TimeOut")).toInt(),
+                true); // don't save this notification again; see this as a user interaction
+            list.endGroup();
+            list.remove(date);
+        }
+    }
 }

--- a/src/notifyd.h
+++ b/src/notifyd.h
@@ -33,6 +33,9 @@
 #include <QObject>
 #include <QVariantMap>
 #include <QStringList>
+#include <QPointer>
+#include <QSystemTrayIcon>
+#include <QMenu>
 
 #include "notificationarea.h"
 #include <LXQt/Settings>
@@ -79,6 +82,7 @@ public slots:
      * \param actions User selectable action list. See specification for more info.
      * \param hints Notification hints. See specification for more info.
      * \param expire_timeout how long should be this notification displayed (-1 = server decides; 0 forever; >0timeout in milliseconds)
+     * \param noSave never save or remember this notification; always assume it is closed by user
      */
     uint Notify(const QString& app_name,
                 uint replaces_id,
@@ -87,7 +91,8 @@ public slots:
                 const QString& body,
                 const QStringList& actions,
                 const QVariantMap& hints,
-                int expire_timeout);
+                int expire_timeout,
+                bool noSave = false);
 
 signals:
     // signals for DBUS API specs - going outside
@@ -122,7 +127,8 @@ signals:
      */
     void notificationAdded(uint id, const QString &application, const QString &title,
                            const QString &description, const QString &icon,
-                           int timeout, const QStringList& actions, const QVariantMap& hints);
+                           int timeout, const QStringList& actions, const QVariantMap& hints,
+                           bool noSave);
 
 private:
     uint mId;
@@ -131,8 +137,17 @@ private:
 
     LXQt::Settings *m_settings;
 
+    QPointer<QSystemTrayIcon> m_trayIcon;
+    QPointer<QMenu> m_trayMenu;
+    int m_trayChecker;
+
+    void createTrayIcon();
+
 private slots:
     void reloadSettings();
+    void checkTray();
+    void addToUnattendedList(uint id, uint reason, const QString &date);
+    void restoreUnattended();
 };
 
 #endif // NOTIFYD_H


### PR DESCRIPTION
Closes https://github.com/lxqt/lxqt/issues/1573

The list is on a menu that can be shown by left/right clicking the new notification tray icon. The icon appears only if there is an unattended notification and, of course, if its spin-box has a positive value in `Desktop Notifications` → `Advanced Settings`. There is also an option for blacklisting.

If a menu-item is clicked, its corresponding notification will be shown and considered attanded, so that it'll be removed from the list. The actuall list is saved in `~/.cache/lxqt-notificationd/unattended.list` (thanks to @Vladimir-csp). Etc.