### PR TITLE
Set max. number of saved notifications to 10

### DIFF
--- a/config/advancedsettings.cpp
+++ b/config/advancedsettings.cpp
@@ -58,7 +58,7 @@ void AdvancedSettings::restoreSettings()
 
     spacingBox->setValue(mSettings->value(QL1S("spacing"), 6).toInt());
     widthBox->setValue(mSettings->value(QL1S("width"), 300).toInt());
-    unattendedBox->setValue(mSettings->value(QL1S("unattendedMaxNum"), 0).toInt());
+    unattendedBox->setValue(mSettings->value(QL1S("unattendedMaxNum"), 10).toInt());
     blackListEdit->setText(mSettings->value(QL1S("blackList")).toStringList().join (QL1S(",")));
 }
 

--- a/src/notifyd.cpp
+++ b/src/notifyd.cpp
@@ -149,7 +149,7 @@ uint Notifyd::Notify(const QString& app_name,
 void Notifyd::reloadSettings()
 {
     m_serverTimeout = m_settings->value(QSL("server_decides"), 10).toInt();
-    int maxNum = m_settings->value(QSL("unattendedMaxNum"), 0).toInt();
+    int maxNum = m_settings->value(QSL("unattendedMaxNum"), 10).toInt();
     m_area->setSettings(
             m_settings->value(QSL("placement"), QSL("bottom-right")).toString().toLower(),
             m_settings->value(QSL("width"), 300).toInt(),


### PR DESCRIPTION
To enable saving by default.

BTW, the code structure of `lxqt-notificationd` has a flaw that should be corrected separately: the default values are set twice, once in `AdvancedSettings`, the other time in `Notifyd`. Classes shouldn't share hidden info with each other.