### PR TITLE
"fix" issue #208 "Customize behaviour on multi-screen setups

### DIFF
--- a/config/advancedsettings.cpp
+++ b/config/advancedsettings.cpp
@@ -43,8 +43,7 @@ AdvancedSettings::AdvancedSettings(LXQt::Settings* settings, QWidget *parent):
     connect(widthBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &AdvancedSettings::save);
     connect(unattendedBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &AdvancedSettings::save);
     connect(blackListEdit, &QLineEdit::editingFinished, this, &AdvancedSettings::save);
-    connect(primarybtn, &QRadioButton::clicked, this, &AdvancedSettings::save);
-    connect(mousebtn, &QRadioButton::clicked, this, &AdvancedSettings::save);
+    connect(mousebtn, &QCheckBox::clicked, this, &AdvancedSettings::save);
 }
 
 AdvancedSettings::~AdvancedSettings()
@@ -63,9 +62,10 @@ void AdvancedSettings::restoreSettings()
     unattendedBox->setValue(mSettings->value(QL1S("unattendedMaxNum"), 10).toInt());
     blackListEdit->setText(mSettings->value(QL1S("blackList")).toStringList().join (QL1S(",")));
 
-    // 1 -> Screen with mouse
-    // 0 -> Default, notification will show up on primary screen
-    int screenNotification = mSettings->value(QL1S("screen_notification"), 0).toInt();
+    // true -> Screen with mouse
+    // false -> Default, notification will show up on primary screen
+    bool screenNotification = mSettings->value(QL1S("screenWithMouse"), false).toBool();
+
     // TODO: it would be nice to put more options here such as:
     // fixed screen to display notification
     // notification shows in all screens (is it worthy the increased ram usage?)
@@ -73,7 +73,7 @@ void AdvancedSettings::restoreSettings()
     if (screenNotification)
         mousebtn->setChecked(true);
     else
-        primarybtn->setChecked(true);
+        mousebtn->setChecked(false);
 }
 
 void AdvancedSettings::save()
@@ -83,10 +83,10 @@ void AdvancedSettings::save()
     mSettings->setValue(QL1S("width"), widthBox->value());
     mSettings->setValue(QL1S("unattendedMaxNum"), unattendedBox->value());
 
-    if (primarybtn->isChecked())
-        mSettings->setValue(QL1S("screen_notification"),0);
+    if (mousebtn->isChecked())
+        mSettings->setValue(QL1S("screenWithMouse"),true);
     else
-        mSettings->setValue(QL1S("screen_notification"),1);
+        mSettings->setValue(QL1S("screenWithMouse"),false);
 
     QString blackList = blackListEdit->text();
     if (!blackList.isEmpty())

--- a/config/advancedsettings.cpp
+++ b/config/advancedsettings.cpp
@@ -43,6 +43,8 @@ AdvancedSettings::AdvancedSettings(LXQt::Settings* settings, QWidget *parent):
     connect(widthBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &AdvancedSettings::save);
     connect(unattendedBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &AdvancedSettings::save);
     connect(blackListEdit, &QLineEdit::editingFinished, this, &AdvancedSettings::save);
+    connect(primarybtn, &QRadioButton::clicked, this, &AdvancedSettings::save);
+    connect(mousebtn, &QRadioButton::clicked, this, &AdvancedSettings::save);
 }
 
 AdvancedSettings::~AdvancedSettings()
@@ -60,6 +62,18 @@ void AdvancedSettings::restoreSettings()
     widthBox->setValue(mSettings->value(QL1S("width"), 300).toInt());
     unattendedBox->setValue(mSettings->value(QL1S("unattendedMaxNum"), 10).toInt());
     blackListEdit->setText(mSettings->value(QL1S("blackList")).toStringList().join (QL1S(",")));
+
+    // 1 -> Screen with mouse
+    // 0 -> Default, notification will show up on primary screen
+    int screenNotification = mSettings->value(QL1S("screen_notification"), 0).toInt();
+    // TODO: it would be nice to put more options here such as:
+    // fixed screen to display notification
+    // notification shows in all screens (is it worthy the increased ram usage?)
+
+    if (screenNotification)
+        mousebtn->setChecked(true);
+    else
+        primarybtn->setChecked(true);
 }
 
 void AdvancedSettings::save()
@@ -68,6 +82,12 @@ void AdvancedSettings::save()
     mSettings->setValue(QL1S("spacing"), spacingBox->value());
     mSettings->setValue(QL1S("width"), widthBox->value());
     mSettings->setValue(QL1S("unattendedMaxNum"), unattendedBox->value());
+
+    if (primarybtn->isChecked())
+        mSettings->setValue(QL1S("screen_notification"),0);
+    else
+        mSettings->setValue(QL1S("screen_notification"),1);
+
     QString blackList = blackListEdit->text();
     if (!blackList.isEmpty())
     {

--- a/config/advancedsettings.ui
+++ b/config/advancedsettings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>350</width>
-    <height>442</height>
+    <height>407</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
@@ -178,17 +178,10 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <widget class="QRadioButton" name="primarybtn">
-        <property name="text">
-         <string>Show notifications on primary screen</string>
+       <widget class="QCheckBox" name="mousebtn">
+        <property name="toolTip">
+         <string>When unchecked the notification will always show on primary screen</string>
         </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QRadioButton" name="mousebtn">
         <property name="text">
          <string>Show notifications on screen with the mouse</string>
         </property>

--- a/config/advancedsettings.ui
+++ b/config/advancedsettings.ui
@@ -7,10 +7,60 @@
     <x>0</x>
     <y>0</y>
     <width>350</width>
-    <height>301</height>
+    <height>442</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
+   <item row="3" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Unattended Notifications</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QLabel" name="unattendedLabel">
+          <property name="text">
+           <string>How many to save:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="unattendedBox"/>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <item>
+         <widget class="QLabel" name="blackListLabel">
+          <property name="toolTip">
+           <string>Application name is on the top of notification.</string>
+          </property>
+          <property name="text">
+           <string>Ignore these applications:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="blackListEdit">
+          <property name="toolTip">
+           <string>Application name is on the top of notification.</string>
+          </property>
+          <property name="placeholderText">
+           <string>app1,app2,app3</string>
+          </property>
+          <property name="clearButtonEnabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="1" column="0" rowspan="2" colspan="2">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
@@ -108,7 +158,7 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="5" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -121,52 +171,28 @@
      </property>
     </spacer>
    </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QGroupBox" name="groupBox_3">
+   <item row="4" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
-      <string>Unattended Notifications</string>
+      <string>Screen</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
+     <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
-         <widget class="QLabel" name="unattendedLabel">
-          <property name="text">
-           <string>How many to save:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="unattendedBox"/>
-        </item>
-       </layout>
+       <widget class="QRadioButton" name="primarybtn">
+        <property name="text">
+         <string>Show notifications on primary screen</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
-        <item>
-         <widget class="QLabel" name="blackListLabel">
-          <property name="toolTip">
-           <string>Application name is on the top of notification.</string>
-          </property>
-          <property name="text">
-           <string>Ignore these applications:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="blackListEdit">
-          <property name="toolTip">
-           <string>Application name is on the top of notification.</string>
-          </property>
-          <property name="placeholderText">
-           <string>app1,app2,app3</string>
-          </property>
-          <property name="clearButtonEnabled">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <widget class="QRadioButton" name="mousebtn">
+        <property name="text">
+         <string>Show notifications on screen with the mouse</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/notificationarea.cpp
+++ b/src/notificationarea.cpp
@@ -79,18 +79,17 @@ void NotificationArea::setHeight(int contentHeight)
     // After we change the primary screen with xrandr, Qt still returns the same value.
     // I think it's a bug of Qt.
 
-    // QDesktopWidget is obsolete in Qt5 and probably will be removed in Qt6, so I guess QScreen is the way to go.
     QRect workArea{};
-
+    const auto screens = qApp->screens();
     if (m_screen) {    // Let's find in which screen the mouse is
-        for (auto &screens: qApp->screens()) {
+        for (const auto &screens: screens) {
             if (screens->geometry().contains(QCursor::pos())) {
                 workArea = screens->availableGeometry();
                 break;
             }
         }
     } else
-        workArea = qApp->desktop()->availableGeometry(qApp->desktop()->primaryScreen());
+        workArea = qApp->primaryScreen()->availableGeometry();
 
     //TODO: perhaps we should check if workArea is valid, don't we?
 
@@ -136,7 +135,7 @@ void NotificationArea::setHeight(int contentHeight)
     ensureVisible(0, contentHeight, 0, 0);
 }
 
-void NotificationArea::setSettings(const QString &placement, int width, int spacing, int unattendedMaxNum, int screen, const QStringList &blackList)
+void NotificationArea::setSettings(const QString &placement, int width, int spacing, int unattendedMaxNum, bool screen, const QStringList &blackList)
 {
     m_placement = placement;
 

--- a/src/notificationarea.cpp
+++ b/src/notificationarea.cpp
@@ -34,7 +34,8 @@
 
 NotificationArea::NotificationArea(QWidget *parent)
     : QScrollArea(parent),
-      m_spacing(-1)
+      m_spacing(-1),
+      m_screenWithMouse(false)
 {
     setObjectName(QSL("NotificationArea"));
 

--- a/src/notificationarea.cpp
+++ b/src/notificationarea.cpp
@@ -68,7 +68,7 @@ NotificationArea::NotificationArea(QWidget *parent)
     connect(qApp->primaryScreen(), &QScreen::availableGeometryChanged, this, &NotificationArea::availableGeometryChanged);
     m_screensList.append(qApp->primaryScreen());
 
-    updateWorkArea();
+    updateWorkScreen();
 }
 
 void NotificationArea::screenAdded(QScreen *screen)
@@ -87,14 +87,14 @@ void NotificationArea::screenRemoved(QScreen *screen)
 
      // after removing it from screensList we can call updateWorkArea(), at this point Qt didnt deleted the screen from QGuiApplication::screens() so we can't use QGuiApplication::screens() in updateWorkArea()
      if (m_workScreen == screen)
-         updateWorkArea();
+         updateWorkScreen();
 }
 
 void NotificationArea::primaryScreenChanged(QScreen *screen)
 {
     Q_UNUSED(screen);
     if (!m_screenWithMouse)
-        updateWorkArea();
+        updateWorkScreen();
 }
 
 void NotificationArea::availableGeometryChanged(const QRect& geometry)
@@ -103,7 +103,7 @@ void NotificationArea::availableGeometryChanged(const QRect& geometry)
     if (isVisible() && m_workScreen->geometry().contains(geometry) )
         setHeight(-1);
 }
-void NotificationArea::updateWorkArea()
+void NotificationArea::updateWorkScreen()
 {
     if (m_screenWithMouse)
     {
@@ -141,7 +141,7 @@ void NotificationArea::setHeight(int contentHeight)
     // avoids unnecessary updates in workArea
     if (!m_workScreen || (m_screenWithMouse && !m_workScreen->geometry().contains(QCursor::pos())) || (!m_screenWithMouse && (qApp->primaryScreen()!=m_workScreen)))
     {
-            updateWorkArea();
+        updateWorkScreen();
     }
 
     QRect workArea = m_workScreen->availableGeometry();

--- a/src/notificationarea.cpp
+++ b/src/notificationarea.cpp
@@ -80,11 +80,11 @@ void NotificationArea::setHeight(int contentHeight)
     // I think it's a bug of Qt.
 
     QRect workArea{};
-    const auto screens = qApp->screens();
     if (m_screen) {    // Let's find in which screen the mouse is
-        for (const auto &screens: screens) {
-            if (screens->geometry().contains(QCursor::pos())) {
-                workArea = screens->availableGeometry();
+        const auto screens = qApp->screens();
+        for (const auto &screen: screens) {
+            if (screen->geometry().contains(QCursor::pos())) {
+                workArea = screen->availableGeometry();
                 break;
             }
         }

--- a/src/notificationarea.cpp
+++ b/src/notificationarea.cpp
@@ -59,7 +59,6 @@ NotificationArea::NotificationArea(QWidget *parent)
     connect(m_layout, &NotificationLayout::allNotificationsClosed, this, &NotificationArea::close);
     connect(m_layout, &NotificationLayout::notificationAvailable, this, &NotificationArea::show);
     connect(m_layout, &NotificationLayout::heightChanged, this, &NotificationArea::setHeight);
-
     connect(qApp, &QGuiApplication::primaryScreenChanged, this, &NotificationArea::primaryScreenChanged);
 }
 
@@ -158,7 +157,7 @@ void NotificationArea::setHeight(int contentHeight)
     ensureVisible(0, contentHeight, 0, 0);
 }
 
-void NotificationArea::setSettings(const QString &placement, int width, int spacing, int unattendedMaxNum, bool screen, const QStringList &blackList) {
+void NotificationArea::setSettings(const QString &placement, int width, int spacing, int unattendedMaxNum, bool screenWithMouse, const QStringList &blackList) {
     m_placement = placement;
 
     setMaximumWidth(width);
@@ -167,7 +166,7 @@ void NotificationArea::setSettings(const QString &placement, int width, int spac
     m_spacing = spacing;
     m_layout->setSizes(m_spacing, width);
 
-    m_screenWithMouse = screen;
+    m_screenWithMouse = screenWithMouse;
 
     if (m_screenWithMouse)
     {

--- a/src/notificationarea.cpp
+++ b/src/notificationarea.cpp
@@ -1,5 +1,5 @@
 /* BEGIN_COMMON_COPYRIGHT_HEADER
- * (c)LGPL2
+ * (c)LGPL2+
  *
  * LXQt - a lightweight, Qt based, desktop toolset
  * https://lxqt.org

--- a/src/notificationarea.cpp
+++ b/src/notificationarea.cpp
@@ -63,7 +63,7 @@ NotificationArea::NotificationArea(QWidget *parent)
     connect(m_layout, &NotificationLayout::heightChanged, this, &NotificationArea::setHeight);
 
     // Since m_screenWithMouse may be or become true, we connect to all screens
-    // but ignore the irrelevant screens in availableGeometryChanged().
+    // but ignore the irrelevant screens
     connect(qApp, &QGuiApplication::screenAdded, this, [this] (QScreen* newScreen){
         connect(newScreen, &QScreen::availableGeometryChanged, this, &NotificationArea::availableGeometryChanged);
     });
@@ -78,7 +78,7 @@ NotificationArea::NotificationArea(QWidget *parent)
     }
 }
 
-void NotificationArea::availableGeometryChanged(const QRect& availableGeometry)
+void NotificationArea::availableGeometryChanged(/*const QRect& availableGeometry*/)
 {
     // if its not visible then there is no need to change its height now
     // (it will be adjusted every time a notification is added/closed)

--- a/src/notificationarea.cpp
+++ b/src/notificationarea.cpp
@@ -75,12 +75,14 @@ void NotificationArea::screenRemoved(QScreen *screen)
 
 void NotificationArea::primaryScreenChanged(QScreen *screen)
 {
+    Q_UNUSED(screen);
     if (!m_screenWithMouse && isVisible())
         setHeight(-1);
 }
 
 void NotificationArea::availableGeometryChanged(const QRect& geometry)
 {
+    Q_UNUSED(geometry);
     if (!isVisible()) // this prevents from accidentally moving currently displaying notification to another screen if m_screenWithMouse is true
         setHeight(-1);
 }

--- a/src/notificationarea.h
+++ b/src/notificationarea.h
@@ -62,18 +62,13 @@ private:
     QString m_placement;
     int m_spacing;
     bool m_screenWithMouse;
-    QScreen* m_workScreen;
-    QList<QScreen*> m_screensList;
 private slots:
     /*! Recalculate widget size and visibility. Slot is called from \c Notificationlayout
      * on demand (notification appear or is closed).
      */
     void setHeight(int contentHeight = -1);
-    void screenAdded(QScreen *screen);
-    void screenRemoved(QScreen *screen);
-    void primaryScreenChanged(QScreen* screen);
     void availableGeometryChanged(const QRect& geometry);
-    void updateWorkScreen();
+
 };
 
 #endif // NOTIFICATIONAREA_H

--- a/src/notificationarea.h
+++ b/src/notificationarea.h
@@ -54,14 +54,14 @@ public:
      * \param unattendedMaxNum the max. number of unattended notifications to be saved
      * \param blackList the list of apps whose unattended notifications aren't saved
      */
-    void setSettings(const QString &placement, int width, int spacing, int unattendedMaxNum, int screen, const QStringList &blackList);
+    void setSettings(const QString &placement, int width, int spacing, int unattendedMaxNum, bool screen, const QStringList &blackList);
 
 private:
     NotificationLayout *m_layout;
 
     QString m_placement;
     int m_spacing;
-    int m_screen;
+    bool m_screen;
 
 private slots:
     /*! Recalculate widget size and visibility. Slot is called from \c Notificationlayout

--- a/src/notificationarea.h
+++ b/src/notificationarea.h
@@ -54,13 +54,14 @@ public:
      * \param unattendedMaxNum the max. number of unattended notifications to be saved
      * \param blackList the list of apps whose unattended notifications aren't saved
      */
-    void setSettings(const QString &placement, int width, int spacing, int unattendedMaxNum, const QStringList &blackList);
+    void setSettings(const QString &placement, int width, int spacing, int unattendedMaxNum, int screen, const QStringList &blackList);
 
 private:
     NotificationLayout *m_layout;
 
     QString m_placement;
     int m_spacing;
+    int m_screen;
 
 private slots:
     /*! Recalculate widget size and visibility. Slot is called from \c Notificationlayout

--- a/src/notificationarea.h
+++ b/src/notificationarea.h
@@ -61,13 +61,16 @@ private:
 
     QString m_placement;
     int m_spacing;
-    bool m_screen;
-
+    bool m_screenWithMouse;
 private slots:
     /*! Recalculate widget size and visibility. Slot is called from \c Notificationlayout
      * on demand (notification appear or is closed).
      */
     void setHeight(int contentHeight = -1);
+    void screenAdded(QScreen *screen);
+    void screenRemoved(QScreen *screen);
+    void primaryScreenChanged(QScreen* screen);
+    void availableGeometryChanged(const QRect& geometry);
 };
 
 #endif // NOTIFICATIONAREA_H

--- a/src/notificationarea.h
+++ b/src/notificationarea.h
@@ -67,7 +67,7 @@ private slots:
      * on demand (notification appear or is closed).
      */
     void setHeight(int contentHeight = -1);
-    void availableGeometryChanged(const QRect& geometry);
+    void availableGeometryChanged(/*const QRect& availableGeometry*/);
 
 };
 

--- a/src/notificationarea.h
+++ b/src/notificationarea.h
@@ -73,7 +73,7 @@ private slots:
     void screenRemoved(QScreen *screen);
     void primaryScreenChanged(QScreen* screen);
     void availableGeometryChanged(const QRect& geometry);
-    void updateWorkArea();
+    void updateWorkScreen();
 };
 
 #endif // NOTIFICATIONAREA_H

--- a/src/notificationarea.h
+++ b/src/notificationarea.h
@@ -54,7 +54,7 @@ public:
      * \param unattendedMaxNum the max. number of unattended notifications to be saved
      * \param blackList the list of apps whose unattended notifications aren't saved
      */
-    void setSettings(const QString &placement, int width, int spacing, int unattendedMaxNum, bool screen, const QStringList &blackList);
+    void setSettings(const QString &placement, int width, int spacing, int unattendedMaxNum, bool screenWithMouse, const QStringList &blackList);
 
 private:
     NotificationLayout *m_layout;

--- a/src/notifyd.cpp
+++ b/src/notifyd.cpp
@@ -155,6 +155,7 @@ void Notifyd::reloadSettings()
             m_settings->value(QSL("width"), 300).toInt(),
             m_settings->value(QSL("spacing"), 6).toInt(),
             maxNum,
+            m_settings->value(QSL("screen_notification"),0).toInt(),
             m_settings->value(QSL("blackList")).toStringList());
 
     if (maxNum > 0 && m_trayIcon.isNull())

--- a/src/notifyd.cpp
+++ b/src/notifyd.cpp
@@ -155,7 +155,7 @@ void Notifyd::reloadSettings()
             m_settings->value(QSL("width"), 300).toInt(),
             m_settings->value(QSL("spacing"), 6).toInt(),
             maxNum,
-            m_settings->value(QSL("screen_notification"),0).toInt(),
+            m_settings->value(QSL("screenWithMouse"),false).toBool(),
             m_settings->value(QSL("blackList")).toStringList());
 
     if (maxNum > 0 && m_trayIcon.isNull())


### PR DESCRIPTION
allow user to select in config if the notification should show on primary screen or screen that contains mouse on it.