### PR TITLE
Added new hints names as image_data and image_path are deprecated.

### DIFF
--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -93,7 +93,7 @@ void Notification::setValues(const QString &application,
     //  - app_icon parameter
     //  - for compatibility reason, "icon_data", "image_data" and "image_path"
 
-    if (!hints[QL1S("image-data")].isNull()) // issue #133: it must be evaluated before icon_data, spotify sends icon_data from the first played song again and again
+    if (!hints[QL1S("image-data")].isNull())
     {
         m_pixmap = getPixmapFromHint(hints[QL1S("image-data")]);
     }

--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -91,10 +91,19 @@ void Notification::setValues(const QString &application,
     //  - "image-data"
     //  - "image-path"
     //  - app_icon parameter
-    //  - for compatibility reason, "icon_data"
-    if (!hints[QL1S("image_data")].isNull())
+    //  - for compatibility reason, "icon_data", "image_data" and "image_path"
+
+    if (!hints[QL1S("image-data")].isNull()) // issue #133: it must be evaluated before icon_data, spotify sends icon_data from the first played song again and again
+    {
+        m_pixmap = getPixmapFromHint(hints[QL1S("image-data")]);
+    }
+    else if (!hints[QL1S("image_data")].isNull())
     {
         m_pixmap = getPixmapFromHint(hints[QL1S("image_data")]);
+    }
+    else if (!hints[QL1S("image-path")].isNull())
+    {
+        m_pixmap = getPixmapFromHint(hints[QL1S("image-path")]);
     }
     else if (!hints[QL1S("image_path")].isNull())
     {


### PR DESCRIPTION
fixes #133 as spotify only sends the right cover art data as "image-data".