### PR TITLE
Added a preview button, instead of automatic preview

### DIFF
--- a/config/basicsettings.cpp
+++ b/config/basicsettings.cpp
@@ -50,6 +50,8 @@ BasicSettings::BasicSettings(LXQt::Settings* settings, QWidget *parent) :
     connect(bottomCenterRB, &QRadioButton::clicked, this, &BasicSettings::updateNotification);
     connect(bottomRightRB,  &QRadioButton::clicked, this, &BasicSettings::updateNotification);
 
+    connect(previewButton,  &QRadioButton::clicked, this, &BasicSettings::previewNotification);
+
     LXQt::Notification *serverTest = new LXQt::Notification(QString(), this);
     serverTest->queryServerInfo();
 
@@ -108,49 +110,45 @@ void BasicSettings::restoreSettings()
 void BasicSettings::updateNotification()
 {
    QString align;
-   QString str;
     if (topLeftRB->isChecked())
-    {
         align = QL1S("top-left");
-        str = tr("at top left");
-    }
     else if (topCenterRB->isChecked())
-    {
         align = QL1S("top-center");
-        str = tr("at top center");
-    }
     else if (topRightRB->isChecked())
-    {
         align = QL1S("top-right");
-        str = tr("at top right");
-    }
     else if (centerLeftRB->isChecked())
-    {
         align = QL1S("center-left");
-        str = tr("at center left");
-    }
     else if (centerRightRB->isChecked())
-    {
         align = QL1S("center-right");
-        str = tr("at center right");
-    }
     else if (bottomLeftRB->isChecked())
-    {
         align = QL1S("bottom-left");
-        str = tr("at bottom left");
-    }
     else if (bottomCenterRB->isChecked())
-    {
         align = QL1S("bottom-center");
-        str = tr("at bottom center");
-    }
     else // if (bottomRightRB->isChecked())
-    {
         align = QL1S("bottom-right");
-        str = tr("at bottom right");
-    }
 
     mSettings->setValue(QL1S("placement"), align);
+}
+
+void BasicSettings::previewNotification()
+{
+   QString str;
+    if (topLeftRB->isChecked())
+        str = tr("at top left");
+    else if (topCenterRB->isChecked())
+        str = tr("at top center");
+    else if (topRightRB->isChecked())
+        str = tr("at top right");
+    else if (centerLeftRB->isChecked())
+        str = tr("at center left");
+    else if (centerRightRB->isChecked())
+        str = tr("at center right");
+    else if (bottomLeftRB->isChecked())
+        str = tr("at bottom left");
+    else if (bottomCenterRB->isChecked())
+        str = tr("at bottom center");
+    else // if (bottomRightRB->isChecked())
+        str = tr("at bottom right");
 
     LXQt::Notification::notify(tr("Notification demo ") + str,
                                tr("This is a test notification.\n All notifications will now appear here on LXQt."),

--- a/config/basicsettings.cpp
+++ b/config/basicsettings.cpp
@@ -50,7 +50,7 @@ BasicSettings::BasicSettings(LXQt::Settings* settings, QWidget *parent) :
     connect(bottomCenterRB, &QRadioButton::clicked, this, &BasicSettings::updateNotification);
     connect(bottomRightRB,  &QRadioButton::clicked, this, &BasicSettings::updateNotification);
 
-    connect(previewButton,  &QRadioButton::clicked, this, &BasicSettings::previewNotification);
+    connect(previewButton, &QAbstractButton::clicked, this, &BasicSettings::previewNotification);
 
     LXQt::Notification *serverTest = new LXQt::Notification(QString(), this);
     serverTest->queryServerInfo();

--- a/config/basicsettings.h
+++ b/config/basicsettings.h
@@ -45,6 +45,7 @@ public slots:
 
 private slots:
     void updateNotification();
+    void previewNotification();
 
 private:
     LXQt::Settings* mSettings;

--- a/config/basicsettings.ui
+++ b/config/basicsettings.ui
@@ -171,6 +171,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QPushButton" name="previewButton">
+     <property name="text">
+      <string>Preview</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>


### PR DESCRIPTION
With it, it's less likely that the preview notification starts at the previous position. With automatic preview, it always started there and then went to the new position (because there's no way to know exactly when the config file is ready).

The preview button can be clicked by pressing `Enter` too.

Closes https://github.com/lxqt/lxqt-notificationd/issues/236