### PR TITLE
Fix desktop file

### DIFF
--- a/config/lxqt-config-notificationd.desktop.in
+++ b/config/lxqt-config-notificationd.desktop.in
@@ -2,7 +2,7 @@
 Type=Application
 Exec=lxqt-config-notificationd
 Icon=preferences-desktop-notification
-Categories=Settings;DesktopSettings;Qt;LXQt;
+Categories=Settings;DesktopSettings;Qt;
 OnlyShowIn=LXQt;
 
 #TRANSLATIONS_DIR=translations


### PR DESCRIPTION
desktop-file-validate: "Categories" in group "Desktop Entry" contains an unregistered value "LXQt"