### PR TITLE
Don't visualize `default` actions, if nameless

### DIFF
--- a/src/notificationwidgets.cpp
+++ b/src/notificationwidgets.cpp
@@ -91,8 +91,16 @@ NotificationActionsButtonsWidget::NotificationActionsButtonsWidget(const QString
 
     for (const auto &action : qAsConst(m_actions))
     {
-        QPushButton *b = new QPushButton(action.second, this);
-        b->setObjectName(action.first);
+        auto &id    = action.first;
+        auto &label = action.second;
+
+        if (id == m_defaultAction && label.isEmpty())
+        {
+            continue;
+        }
+
+        QPushButton *b = new QPushButton(label, this);
+        b->setObjectName(id);
         // Notifications do not have focus, and if they get focus under Wayland,
         // we do not want to have a focus widget.
         b->setFocusPolicy(Qt::NoFocus);
@@ -125,15 +133,19 @@ NotificationActionsComboWidget::NotificationActionsComboWidget(const QStringList
     m_comboBox->setFocusPolicy(Qt::NoFocus);
     int currentIndex = -1;
 
-    for (int i = 0; i < m_actions.count(); ++i)
+    for (const auto &action : qAsConst(m_actions))
     {
-        auto const & action = m_actions[i];
+        auto &id    = action.first;
+        auto &label = action.second;
 
-        m_comboBox->addItem(action.second, action.first);
-        if (action.first == m_defaultAction)
+        if (id == m_defaultAction)
         {
-            currentIndex = i;
+            if (label.isEmpty())
+                continue;
+            currentIndex = m_comboBox->count();
         }
+
+        m_comboBox->addItem(label, id);
     }
     l->addWidget(m_comboBox);
 


### PR DESCRIPTION
Some major libraries (e.g. GIO) send the `default` action without name/label since they expect notification backends to not show `default` actions explicitly, but lxqt-notificationd does, resulting in an extra, label-less button or combo-box item on notifications sent by, e.g., [Gajim](https://gajim.org) or [Dino](https://dino.im).

With this patch, lxqt-notificationd omits the extra button / combo-box item for the `default` action iff it has no name/label (to preserve the rest of the old behavior in case some programs expect the `default` action *with* a name to be shown explicitly).

Below is a Python 3 script that reproduces the behavior (and tests the patch).

```python3
from gi.repository import Gio

a = Gio.Application()
a.register(None)

n = Gio.Notification()
n.set_body('Body')
n.set_default_action('app.foo')
n.add_button('Do bar!', 'app.bar')
n.add_button('Do baz!', 'app.baz')
# add more for the combo-box UI

a.send_notification(None, n)
```

### Some references

> The name can be anything, though implementations are free not to display it.

-- [the Freedesktop spec on the `default` action](https://specifications.freedesktop.org/notification-spec/1.2/ar01s02.html#idm45889509838320)


> In Plasma and Gnome desktops, [...] the label is not presented to the user.

-- [documentation for `KNotification::defaultAction`](https://api.kde.org/frameworks/knotifications/html/classKNotification.html#a0332a1501a2d212a30dddae9645b0b62)


> This action is activated when the notification is clicked on.

-- [documentation for `g_notification_set_default_action`](https://docs.gtk.org/gio/method.Notification.set_default_action.html)
