### PR TITLE
Port deprecated KWindowSystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
 option(LXQT_NOTIFICATION_BUILD_TESTS "Build LXQt Notification tests" OFF)
 
-set(KF5_MINIMUM_VERSION "5.36.0")
+set(KF5_MINIMUM_VERSION "5.101.0")
 set(LXQT_MINIMUM_VERSION "1.3.0")
 set(QT_MINIMUM_VERSION "5.15.0")
 

--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -33,6 +33,7 @@
 #include <QDebug>
 #include <XdgIcon>
 #include <KWindowSystem/KWindowSystem>
+#include <KWindowSystem/KX11Extras>
 #include <QMouseEvent>
 #include <QPushButton>
 #include <QStyle>
@@ -326,7 +327,7 @@ void Notification::mouseReleaseEvent(QMouseEvent * event)
         return;
     }
 
-    const auto ids = KWindowSystem::stackingOrder();
+    const auto ids = KX11Extras::stackingOrder();
     for (const WId &i : ids)
     {
         KWindowInfo info = KWindowInfo(i, NET::WMName | NET::WMVisibleName);


### PR DESCRIPTION
Bump KF5 minimum version to 5.101.0. KX11Extras was introduced on that
version.
