### PR TITLE
Added PCRE notification filtering/blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,50 @@ menu - Preferences - LXQt Settings - Desktop Notifications and is provided by th
 [Configuration Center](https://github.com/lxqt/lxqt-config#configuration-center)
 of [lxqt-config](https://github.com/lxqt/lxqt-config) as well.
 
+### Filtering
+It is possible to filter/suppress notifications with a [PCRE](https://www.pcre.org) by setting the
+`application_pcre_filter`, `body_pcre_filter`, or `summary_pcre_filter` in the
+`lxqt/notifications.conf`. These variables can be set with any valid PCRE with 
+each section being checked against its respective PCRE filter. If any of the
+PCREs are captured in the application, body, or summary then the message will 
+not be shown. The following example `lxqt/notifications.conf` any notification with the
+summary containing the words "hello", "goodbye", or "nope" will not be shown:
+```text
+[General]
+...
+application_pcre_filter=
+body_pcre_filter=
+summary_pcre_filter=(?:hello|goodbye|nope)
+...
+```
+https://regex101.com/r/nhtRtx/1
+
+#### Filtering Examples
+Filter/block all notifications from the applications: `noisy_app1`,
+`noisy_app2`, and `noisy_app3`.
+Add the following to lxqt/notification.conf:
+```text
+[General]
+...
+applicaiton_pcre_filter=(?:noisy_app1|noisy_app2|noisy_app3)
+body_pcre_filter=
+summary_pcre_filter=
+...
+```
+
+Filter/block all notifications containing the strings: `This is a test` and
+`This is another test`
+```text
+[General]
+...
+applicaiton_pcre_filter=
+body_pcre_filter=
+summary_pcre_filter=^(?=.*(?:This is a test|This is another test)).*$
+...
+```
+https://regex101.com/r/thW0qo/1
+
+
 ## Translations
 
 Translations can be done in [LXQt-Weblate](https://translate.lxqt-project.org/projects/lxqt-configuration/lxqt-notificationd)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ lxqt_translate_ts(NOTIFICATIONS_QM_FILES
 lxqt_app_translation_loader(QM_LOADER ${PROJECT_NAME})
 #************************************************
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions")
 add_executable(lxqt-notificationd
     ${NOTIFICATIONS_SRC}
     ${NOTIFICATIONS_QM_FILES}

--- a/src/notificationlayout.h
+++ b/src/notificationlayout.h
@@ -53,6 +53,18 @@ public:
     void setDoNotDisturb(bool value) {
         m_doNotDisturb = value;
     }
+ 
+    void setApplicationPCREFilter(const std::string& pcre) {
+        m_application_pcre_filter = pcre;
+    }
+
+    void setBodyPCREFilter(const std::string& pcre) {
+        m_body_pcre_filter = pcre;
+    }
+
+    void setSummaryPCREFilter(const std::string& pcre) {
+        m_summary_pcre_filter = pcre;
+    }
 
     void setBlackList(const QStringList &l) {
         m_blackList = l;
@@ -107,6 +119,9 @@ private:
     QVBoxLayout *m_layout;
     int m_unattendedMaxNum;
     bool m_doNotDisturb;
+    std::string m_application_pcre_filter;
+    std::string m_body_pcre_filter;
+    std::string m_summary_pcre_filter;
     QStringList m_blackList;
     QString m_cacheFile;
     QString m_cacheDateFormat;
@@ -116,6 +131,8 @@ private:
      * Also heightChanged() is emitted here.
      */
     void checkHeight();
+
+    bool filter(const std::string& input, const std::string& pcre);
 
 private slots:
     /*! \c Notification's timer timeouted, so closing the notifiaction

--- a/src/notifyd.cpp
+++ b/src/notifyd.cpp
@@ -155,6 +155,10 @@ void Notifyd::reloadSettings()
     m_serverTimeout = m_settings->value(QSL("server_decides"), 10).toInt();
     bool old_doNotDisturb = m_doNotDisturb;
     m_doNotDisturb = m_settings->value(QL1S("doNotDisturb"), false).toBool();
+    std::string m_application_pcre_filter = m_settings->value(QL1S("application_pcre_filter")).toString().toStdString();
+    std::string m_body_pcre_filter = m_settings->value(QL1S("body_pcre_filter")).toString().toStdString();
+    std::string m_summary_pcre_filter = m_settings->value(QL1S("summary_pcre_filter")).toString().toStdString();
+
     int maxNum = m_settings->value(QSL("unattendedMaxNum"), 10).toInt();
     if (m_doNotDisturb)
         maxNum = qMax(maxNum, 50);
@@ -166,6 +170,9 @@ void Notifyd::reloadSettings()
             m_settings->value(QSL("screenWithMouse"),false).toBool(),
             m_doNotDisturb ? QStringList() : m_settings->value(QSL("blackList")).toStringList());
     m_area->layout()->setDoNotDisturb(m_doNotDisturb);
+    m_area->layout()->setApplicationPCREFilter(m_application_pcre_filter);
+    m_area->layout()->setBodyPCREFilter(m_body_pcre_filter);
+    m_area->layout()->setSummaryPCREFilter(m_summary_pcre_filter);
 
     if (m_trayIcon.isNull())
     {


### PR DESCRIPTION
# Background
This PR adds [PCRE](https://www.pcre.org/) message filtering and blocking.

Many applications offer no ability or limited ability to configure notifications.
This is annoying is a particular application is sending too many notifications
There may be some interesting notifications that an application offers and some
annoying ones with no way to configure fine grain control of this.

## Why does this need to exist
Some applications do not allow you to configure notifications or do not support
granular notification settings. The black list feature does not work as expected 
or desired. This feature could be rolled into the black list if desired.

This PR offers a simple and powerful way to filter/block messages with a PCRE 
no matter how the notifications are generated.

Messages can be filtered on: `application`, `body` or `summary` by setting
either `application_pcre_filter`, `body_pcre_filter` and/or `summary_pcre_filter`
in the `lxqt/notifications.conf`.

If the application string is captured by the PCRE set by `application_pcre_filter`
then the notification will not be shown, same goes for the body and summary.


## Changes
1. 3 new configuration parameters were added to the QSettings con fig file: 
`application_pcre_filter`, `body_pcre_filter`, and `summary_pcre_filter`
2. Exceptions were enabled in `src/CMakeLists.txt` for the lxqt-notificationd
target.
- Compiling PCREs at runtime can generate exceptions.  If the user provides a 
PCRE containing a syntax error then lxqt-notificationd should simply ignore it
instead of crashing. 
