### PR TITLE
Added Debian bookworm dockerfile and makefile to build and run lxqt-notificationd 

### DIFF
--- a/docker/Dockerfile.debian_bookworm
+++ b/docker/Dockerfile.debian_bookworm
@@ -1,0 +1,18 @@
+FROM debian:bookworm 
+
+RUN apt-get update && \
+    apt-get install -y cmake g++ && \
+    apt-get install -y --no-install-recommends qtbase5-dev qttools5-dev libkf5windowsystem-dev liblxqt1-dev libqt5x11extras5-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /tmp/lxqt-notificationd
+WORKDIR /tmp/lxqt-notificationd
+
+RUN mkdir -p /var/run/dbus
+
+
+COPY . .
+RUN mkdir build && \
+    cd build && \
+    cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=/usr && \
+    make

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,33 @@
+SHELL:=/bin/bash
+
+.DEFAULT_GOAL := build 
+
+PROJECT:=lxqt-notificationd
+TAG:=latest
+
+.EXPORT_ALL_VARIABLES:
+DOCKER_BUILDKIT?=1
+DOCKER_CONFIG?=
+
+DOCKERFILE=Dockerfile.debian_bookworm
+
+.PHONY: build
+build: clean
+	cd .. && sed -i "s|1.4.0|1.2.0|g" CMakeLists.txt 
+	cd .. && docker build -f "docker/${DOCKERFILE}" -t ${PROJECT}:${TAG}  .
+	git checkout -- ../CMakeLists.txt
+	cd .. && docker cp $$(docker create --rm ${PROJECT}:${TAG}):/tmp/lxqt-notificationd/build .
+	cd .. && docker cp $$(docker create --rm ${PROJECT}:${TAG}):/usr/lib/x86_64-linux-gnu/liblxqt.so.1 build
+	cd .. && docker cp $$(docker create --rm ${PROJECT}:${TAG}):/usr/lib/x86_64-linux-gnu/liblxqt.so.1.2.0 build
+
+
+.PHONY: clean
+clean: 
+	cd .. && rm -rf build 
+	docker rm $$(docker ps -a -q --filter "ancestor=${PROJECT}:${TAG}") --force 2> /dev/null || true
+	docker rmi $$(docker images -q ${PROJECT}:${TAG}) --force 2> /dev/null || true
+
+
+.PHONY: run
+run:
+	LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:$(shell realpath ../build)" ./../build/src/lxqt-notificationd


### PR DESCRIPTION
This PR simply adds a Makefile and Dockerfile to build and run lxqt-notificaitond.  It was quite the pain to get a development environment set up. I feel like this could help someone else.

## Usage
```bash
cd docker
make build
make run
```
> All processes registered to `org.freedesktop.Notificaiton` must be halted before launching lxqt-notificaitond this way