### PR TITLE
Fixed a crash on killing the process

### DIFF
--- a/src/notifyd.cpp
+++ b/src/notifyd.cpp
@@ -70,9 +70,9 @@ Notifyd::Notifyd(QObject* parent)
 
 Notifyd::~Notifyd()
 {
-    m_trayMenu->deleteLater();
-    m_trayIcon->deleteLater();
-    m_area->deleteLater();
+    delete m_trayMenu;
+    delete m_trayIcon;
+    delete m_area;
 }
 
 void Notifyd::CloseNotification(uint id)


### PR DESCRIPTION
The crash was in `QObject::deleteLater()` and started to happen for me with Qt 6.7 (on Wayland).