### PR TITLE
Workaround for translucency artifacts with Qt 6.8.0 on Wayland

### DIFF
--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -237,6 +237,19 @@ void Notification::paintEvent(QPaintEvent *)
     QStyleOption opt;
     opt.initFrom(this);
     QPainter p(this);
+
+#if (QT_VERSION >= QT_VERSION_CHECK(6,8,0))
+    // NOTE: Starting from Qt 6.8.0, random artifacts are possible in
+    // translucent windows under Wayland. This a workaround.
+    if (QGuiApplication::platformName() == QStringLiteral("wayland"))
+    {
+        auto origMode = p.compositionMode();
+        p.setCompositionMode(QPainter::CompositionMode_Clear);
+        p.fillRect(rect(), Qt::transparent);
+        p.setCompositionMode(origMode);
+    }
+#endif
+
     style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
 }
 


### PR DESCRIPTION
Because of a regression Qt 6.8.0, random artifacts are possible in translucent windows under Wayland. These artifacts consist of random opaque regions inside a translucent window and are created mostly when the widget is resized before or after being shown.

The patch adds a simple workaround for LXQt notifications by making their pixels fully transparent before painting them. The workaround will be safe if the issue is fixed in Qt, although I don't think that will happen soon.

NOTE: I encountered the same problem in all translucent windows with Kvantum + Qt 6.8.0, and the workaround was 100% effective.