### PR TITLE
Fixed a problem in decreasing notification width

### DIFF
--- a/src/notificationlayout.cpp
+++ b/src/notificationlayout.cpp
@@ -61,6 +61,7 @@ void NotificationLayout::setSizes(int space, int width)
     m_layout->setSpacing(space);
     setMaximumWidth(width);
     setMinimumWidth(width);
+    resize(width, height()); // needed when the width is decreased (perhaps because of a Qt bug)
 
     QHashIterator<uint, Notification*> it(m_notifications);
     while (it.hasNext())


### PR DESCRIPTION
Previously, if the width was decreased, the layout might become misaligned, probably due to a Qt bug. This is a simple workaround.

Closes https://github.com/lxqt/lxqt-notificationd/issues/411