### PR TITLE
Allow zero duration in config GUI

### DIFF
--- a/config/advancedsettings.cpp
+++ b/config/advancedsettings.cpp
@@ -50,8 +50,6 @@ AdvancedSettings::~AdvancedSettings() = default;
 void AdvancedSettings::restoreSettings()
 {
     int serverDecides = mSettings->value(QL1S("server_decides"), 10).toInt();
-    if (serverDecides <= 0)
-        serverDecides = 10;
     serverDecidesBox->setValue(serverDecides);
 
     unattendedBox->setValue(mSettings->value(QL1S("unattendedMaxNum"), 10).toInt());

--- a/src/notifyd.cpp
+++ b/src/notifyd.cpp
@@ -140,7 +140,7 @@ uint Notifyd::Notify(const QString& app_name,
 #endif
 
     // handling the "server decides" timeout
-    if (expire_timeout == -1) {
+    if (expire_timeout < 0) {
         expire_timeout = m_serverTimeout;
         expire_timeout *= 1000;
     }
@@ -152,7 +152,7 @@ uint Notifyd::Notify(const QString& app_name,
 
 void Notifyd::reloadSettings()
 {
-    m_serverTimeout = m_settings->value(QSL("server_decides"), 10).toInt();
+    m_serverTimeout = qMax(m_settings->value(QSL("server_decides"), 10).toInt(), 0);
     bool old_doNotDisturb = m_doNotDisturb;
     m_doNotDisturb = m_settings->value(QL1S("doNotDisturb"), false).toBool();
     int maxNum = m_settings->value(QSL("unattendedMaxNum"), 10).toInt();


### PR DESCRIPTION
It was allowed in the config file, but the config GUI reset it to 10.

Zero means not closing when there's no explicit timeout.

Closes https://github.com/lxqt/lxqt-notificationd/issues/211