### PR TITLE
Fixed a very old bug revealed by Clang

### DIFF
--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -35,6 +35,7 @@
 #include <KWindowSystem>
 #include <KF6/KWindowSystem/KX11Extras>
 #include <KF6/KWindowSystem/KWindowInfo>
+#include <QEnterEvent>
 #include <QMouseEvent>
 #include <QPushButton>
 #include <QStyle>
@@ -299,7 +300,7 @@ QPixmap Notification::getPixmapFromString(const QString &str) const
     }
 }
 
-void Notification::enterEvent(QEvent * /*event*/)
+void Notification::enterEvent(QEnterEvent * /*event*/)
 {
     if (m_timer)
         m_timer->pause();

--- a/src/notification.h
+++ b/src/notification.h
@@ -92,8 +92,8 @@ signals:
     void actionTriggered(const QString &actionKey);
 
 protected:
-    void enterEvent(QEvent * event);
-    void leaveEvent(QEvent * event);
+    void enterEvent(QEnterEvent * event) override;
+    void leaveEvent(QEvent * event) override;
     /*! Define on-click behavior in the notification area.
         Currently it implements:
             - if there is one action or at least one default action, this
@@ -106,7 +106,7 @@ protected:
               if it can be found the window is raised and the notification is closed
             - leave notification as-is.
     */
-    void mouseReleaseEvent(QMouseEvent * event);
+    void mouseReleaseEvent(QMouseEvent * event) override;
 
 private:
     NotificationTimer *m_timer;
@@ -122,10 +122,10 @@ private:
     QVariantMap m_hints;
 
     // mandatory for stylesheets
-    void paintEvent(QPaintEvent *);
+    void paintEvent(QPaintEvent *) override;
     QPixmap getPixmapFromHint(const QVariant &argument) const;
     QPixmap getPixmapFromString(const QString &str) const;
-    bool eventFilter(QObject *obj, QEvent *event);
+    bool eventFilter(QObject *obj, QEvent *event) override;
 
 private slots:
     void closeButton_clicked();


### PR DESCRIPTION
When the mouse cursor entered a notification window, the code was supposed to prevent it from being closed, but it didn't.

Closes https://github.com/lxqt/lxqt-notificationd/issues/438