### PR TITLE
Fixed time-out after leave event

### DIFF
--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -384,7 +384,6 @@ void NotificationTimer::pause()
         return;
 
     stop();
-    m_intervalMsec = m_startTime.msecsTo(QDateTime::currentDateTime());
 }
 
 void NotificationTimer::resume()
@@ -392,5 +391,6 @@ void NotificationTimer::resume()
     if (isActive())
         return;
 
-    start(m_intervalMsec);
+    m_intervalMsec -= m_startTime.msecsTo(QDateTime::currentDateTime());
+    start(qMax(m_intervalMsec, 1000));
 }


### PR DESCRIPTION
The patch fixes a very old issue:

Suppose that a notification has a time-out of 10 sec, but you put the mouse cursor over its window 1 sec after it pops up and keep it there 4 sec before moving it away from the window. Then the window will disappear after 1 sec, while it should have disappeared after 5 sec.

I also let the notification remain open for one sec if its time-out is passed on moving the cursor away, to prevent a sudden disappearance.

Related to another old bug that was fixed in https://github.com/lxqt/lxqt-notificationd/commit/fa24f525428f940cbf3e9567eda30a2af0d5b06d.